### PR TITLE
Update wgd (i-adhore, paml, pandas, wf1, bugfix)

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -1,5 +1,5 @@
 Bootstrap: docker
-From: ubuntu
+From: vibpsb/i-adhore
 
 %runscript
 	wgd --help
@@ -18,13 +18,17 @@ From: ubuntu
 %post
 	# install python, git, etc.
 	apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -yq install python3-pip python3-tk git wget \
-	    build-essential mcl ncbi-blast+ muscle mafft prank fasttree phyml paml
+	    build-essential mcl ncbi-blast+ muscle mafft prank fasttree phyml
 
-	# set an alias for fasttree
-	ln -s /usr/bin/fasttree /usr/bin/FastTree
+	# Install PAML from source
+	apt-get install -y wget && wget http://abacus.gene.ucl.ac.uk/software/paml4.9j.tgz && \
+	tar -xzf paml4.9j.tgz && cd paml4.9j/src && make -f Makefile && mv codeml /bin && cd /
+
+	# # set an alias for fasttree
+	# ln -s /usr/bin/fasttree /usr/bin/FastTree
 
 	# get wgd
-	git clone https://github.com/arzwa/wgd.git
+	git clone git@github.com:Cecilia-Sensalari/wgd.git
 	cd wgd
 
 	# install wgd

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'scipy>=1.2',
         'matplotlib>=3.0.2',
         'plumbum>=1.6.7',
-        'pandas==0.24.1',
+        'pandas==1.2.0',
         'progressbar2>=3.39',
         'joblib==0.11', # 0.12 seems to break the logging in parallel for loops
         'ete3>=3.1',

--- a/wgd/utils.py
+++ b/wgd/utils.py
@@ -74,7 +74,6 @@ def can_i_run_software(software):
             logging.info('codeml found')
             os.remove(tmp_file)
             try:
-                os.remove("codeml.ctl")
                 subprocess.run(['rm', 'rub', 'rst1', 'rst'])
             except:  # no idea what could happen here
                 pass

--- a/wgd/viz.py
+++ b/wgd/viz.py
@@ -364,7 +364,7 @@ def syntenic_dotplot_ks_colored(
             # pe.Normal()])
 
     # colorbar
-    cbar = plt.colorbar(tmp, fraction=0.02, pad=0.01)
+    cbar = plt.colorbar(tmp, fraction=0.02, pad=0.01, ticks=list(range(0, 110, 10)))
     cbar.ax.set_yticklabels(['{:.2f}'.format(x) for x in np.linspace(0, 5, 11)])
 
     # saving

--- a/wgd_cli.py
+++ b/wgd_cli.py
@@ -1390,6 +1390,14 @@ def viz_(
         '--n_threads', '-n', default=4, show_default=True,
         help="number of threads to use"
 )
+@click.option(
+        '--feature', '-f', default="mRNA", show_default=True,
+        help="Feature column in GFF file"
+)
+@click.option(
+        '--attribute', '-a', default="Parent", show_default=True,
+        help="Attribute column in GFF file"
+)
 def wf1(sequences, output_dir, gff_file, n_threads):
     """
     Standard workflow whole paranome Ks.
@@ -1419,9 +1427,10 @@ def wf1(sequences, output_dir, gff_file, n_threads):
 
     # wgd syn
     if gff_file:
+        os.chdir("..")
         syn_dir = os.path.join(output_dir, 'wgd_syn')
         syn_(gff_file=gff_file, families=mcl_out, output_dir=syn_dir,
-             ks_distribution=ks_results)
+             ks_distribution=ks_results, feature=feature, gene_attribute=attribute)
 
     return
 


### PR DESCRIPTION
Singularity updates:
  - The container is built from vibpsb/i-adhore base image in Docker Hub, so that wgd can run the syn command in the container 
  - PAML is installed from PAML website and not from apt-get
  - pandas is now version 1.2.0
Code changes:
  - Due to the new PAML version, removing the control file was not needed anymore (deleted one line)
  - Bugfix concerning colorbar ticks in the colored dotplot
  - "wf1" command now has feature and attribute arguments for a flexible GFF parsing by i-adhore